### PR TITLE
Bugfix - Add missing libtool dependency to easyrpgplayer

### DIFF
--- a/scriptmodules/ports/easyrpgplayer.sh
+++ b/scriptmodules/ports/easyrpgplayer.sh
@@ -15,7 +15,7 @@ rp_module_menus="4+"
 rp_module_flags="!x86 !mali"
 
 function depends_easyrpgplayer() {
-    getDepends libsdl2-dev libsdl2-mixer-dev libpng12-dev libfreetype6-dev libboost-dev libpixman-1-dev zlib1g-dev autoconf automake libicu-dev
+    getDepends libsdl2-dev libsdl2-mixer-dev libpng12-dev libfreetype6-dev libboost-dev libpixman-1-dev zlib1g-dev autoconf automake libicu-dev libtool
 }
 
 function sources_easyrpgplayer() {


### PR DESCRIPTION
Fixes https://github.com/zerojay/RetroPie-Extra/issues/43.