### PR TITLE
Add kodi with default joypad xmls

### DIFF
--- a/scriptmodules/ports/kodi-extra.sh
+++ b/scriptmodules/ports/kodi-extra.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="kodi-extra"
+rp_module_desc="Kodi - Open source home theatre software"
+rp_module_menus="4+"
+rp_module_flags="nobin !mali"
+
+function depends_kodi-extra() {
+    if isPlatform "rpi"; then
+        if [[ "$__depends_mode" == "install" ]]; then
+            # remove old repository
+            rm -f /etc/apt/sources.list.d/mene.list
+            echo "deb http://dl.bintray.com/pipplware/dists/jessie/main/binary/ ./" >/etc/apt/sources.list.d/pipplware.list
+            wget -q -O- http://pipplware.pplware.pt/pipplware/key.asc | apt-key add - >/dev/null
+        else
+            rm -f /etc/apt/sources.list.d/pipplware.list
+            apt-key del 4096R/BAA567BB >/dev/null
+        fi
+    fi
+}
+
+function install_kodi-extra() {
+    aptInstall kodi
+}
+
+function remove_kodi-extra() {
+    aptRemove kodi
+}
+
+function configure_kodi-extra() {
+    echo 'SUBSYSTEM=="input", GROUP="input", MODE="0660"' > /etc/udev/rules.d/99-input.rules
+
+    mkRomDir "kodi"
+
+    cat > "$romdir/kodi/Kodi.sh" << _EOF_
+#!/bin/bash
+/opt/retropie/supplementary/runcommand/runcommand.sh 0 "kodi-standalone" "kodi"
+_EOF_
+
+    chmod +x "$romdir/kodi/Kodi.sh"
+
+    setESSystem 'Kodi' 'kodi' '~/RetroPie/roms/kodi' '.sh .SH' '%ROM%' 'pc' 'kodi'
+
+    # Install some predefined joypad configurations
+    gitPullOrClone "keymaps" https://github.com/HerbFargus/kodi-joypads.git
+    cp -a keymaps/keymaps/ $home/.kodi/userdata/
+    rm -R keymaps
+    chown $user:$user -R $home/.kodi/userdata/keymaps 
+}


### PR DESCRIPTION
The reason I think this is useful for the time being is: 

- it saves people the manual labour of setting up kodi as its own system
- I've included default joypad controls for ibuffalo and xbox360 
- It's renamed so it doesnt conflict with the main kodi, so there won't be any issues with updating the script

a few caveats, the xml file for the xbox userspace driver doesnt seem to match the values indicated in jstest, it has a few nuances and definitely can be improved, will make things a little more difficult for autogeneration I think.  feel free to improve on my script if needed.

The script pulls from my kodi-joypads repo, so if anyone else wanted to add more controller xmls they can do so here: https://github.com/HerbFargus/kodi-joypads.git