### PR TITLE
add trs-80 emulator sdltrs

### DIFF
--- a/scriptmodules/emulators/sdltrs.sh
+++ b/scriptmodules/emulators/sdltrs.sh
@@ -41,16 +41,16 @@ function configure_sdltrs() {
     mkRomDir "trs-80"
 
     local rom
-    for rom in level2.rom level3.rom level4.rom; do
+    for rom in level2.rom level3.rom level4.rom level4p.rom; do
         ln -sf "$biosdir/$rom" "$md_inst/$rom"
     done
 
 
-    addSystem 1 "$md_id-sdltrs-model1" "trs-80" "xinit $md_inst/sdltrs -model 1 -romfile $biosdir/level1.rom  -showled -diskdir \"$romdir/trs-80\" -disk0 %ROM%" "trs-80" ".dsk"
+    addSystem 1 "$md_id-sdltrs-model1" "trs-80" "xinit $md_inst/sdltrs -model 1 -romfile $biosdir/level2.rom  -showled -diskdir \"$romdir/trs-80\" -disk0 %ROM%" "trs-80" ".dsk"
    addSystem 0 "$md_id-sdltrs-model3" "trs-80" "xinit $md_inst/sdltrs -model 3 -romfile3 $biosdir/level3.rom  -showled -diskdir \"$romdir/trs-80\" -disk0 %ROM%" "trs-80" ".dsk"
     addSystem 0 "$md_id-sdltrs-model4" "trs-80" "xinit $md_inst/sdltrs -model 4 -romfile3 $biosdir/level4.rom  -showled -diskdir \"$romdir/trs-80\" -disk0 %ROM%" "trs-80" ".dsk"
     addSystem 0 "$md_id-sdltrs-model4" "trs-80" "xinit $md_inst/sdltrs -model 4p -romfile4p $biosdir/level4p.rom  -showled -diskdir \"$romdir/trs-80\" -disk0 %ROM%" "trs-80" ".dsk"
     
-    __INFMSGS+=("You need to copy your requires TRS-80 bios files called level2.rom, level3.rom or level4.rom to $biosdir")
+    __INFMSGS+=("You need to copy your requires TRS-80 bios files called level2.rom, level3.rom or level4.rom or level4p.rom to $biosdir")
 }
 

--- a/scriptmodules/emulators/sdltrs.sh
+++ b/scriptmodules/emulators/sdltrs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="sdltrs"
+rp_module_desc="Radio Shack TRS-80 Model I/III/4/4P emulator"
+rp_module_menus="4+"
+rp_module_flags="dispmanx !mali"
+
+function depends_sdltrs() {
+    getDepends libsdl1.2-dev xorg
+}
+
+function sources_sdltrs() {
+    gitPullOrClone "$md_build" https://github.com/HerbFargus/sdltrs.git
+}
+
+function build_sdltrs() {
+    cd src/linux
+    make clean
+    make
+    md_ret_require="$md_build"
+}
+
+function install_sdltrs() {
+    chmod 644 README
+    md_ret_files=(
+        'src/linux/sdltrs'
+        'README'
+    )
+}
+
+function configure_sdltrs() {
+    mkRomDir "trs-80"
+
+    local rom
+    for rom in level2.rom level3.rom level4.rom; do
+        ln -sf "$biosdir/$rom" "$md_inst/$rom"
+    done
+
+
+    addSystem 1 "$md_id-sdltrs-model1" "trs-80" "xinit $md_inst/sdltrs -model 1 -romfile $biosdir/level1.rom  -showled -diskdir \"$romdir/trs-80\" -disk0 %ROM%" "trs-80" ".dsk"
+   addSystem 0 "$md_id-sdltrs-model3" "trs-80" "xinit $md_inst/sdltrs -model 3 -romfile3 $biosdir/level3.rom  -showled -diskdir \"$romdir/trs-80\" -disk0 %ROM%" "trs-80" ".dsk"
+    addSystem 0 "$md_id-sdltrs-model4" "trs-80" "xinit $md_inst/sdltrs -model 4 -romfile3 $biosdir/level4.rom  -showled -diskdir \"$romdir/trs-80\" -disk0 %ROM%" "trs-80" ".dsk"
+    addSystem 0 "$md_id-sdltrs-model4" "trs-80" "xinit $md_inst/sdltrs -model 4p -romfile4p $biosdir/level4p.rom  -showled -diskdir \"$romdir/trs-80\" -disk0 %ROM%" "trs-80" ".dsk"
+    
+    __INFMSGS+=("You need to copy your requires TRS-80 bios files called level2.rom, level3.rom or level4.rom to $biosdir")
+}
+


### PR DESCRIPTION
This unfortunately needs to be called with xinit for now as there is some sort of SDL bug that leaves the framebuffer in an unusable state on exit without it, so I'll have to look further into that before this can be considered for the main repository, but I've tested this and it seems to be working alright. I adapted it from one of @joolswills modules