### PR TITLE
Remove gizmo's videocore N64 plugin from todo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ In the dialog box that comes up, you can select which users are allowed to use t
 - [ ] - SDLash/Xash Half-Life engine through glshim.  
 - [ ] - Beatfever Mania.  
 - [ ] - Stepmania/Frets on Fire through glshim/new OpenGL driver.  
-- [ ] - Mupen64Plus videocore plugin - Awaiting fixed code (gizmo98?)  
 - [ ] - John's Shadow Warrior Port (jswp)  
 
 ### Hall of Fame - Scripts accepted into RetroPie-Setup


### PR DESCRIPTION
Already added to Retropie.