### PR TITLE
Add standalone option to install Cave Story (NXEngine)

### DIFF
--- a/scriptmodules/ports/nxengine.sh
+++ b/scriptmodules/ports/nxengine.sh
@@ -20,7 +20,7 @@ function depends_nxengine() {
 
 function sources_nxengine() {
     if isPlatform "rpi"; then 
-        wget -O- -q http://www.cavestory.org/downloads/pi-NXEngine-master.zip
+        wget -O pi-NXEngine-master.zip "http://www.cavestory.org/downloads/pi-NXEngine-master.zip"
         unzip -oj pi-NXEngine-master.zip -d "$md_inst"
         rm pi-NXEngine-master.zip
         cd "$md_inst"
@@ -36,7 +36,7 @@ function sources_nxengine() {
 
 function install_bin_nxengine() {
     if isPlatform "rpi"; then
-        wget -O- -q http://www.sheasilverman.com/rpi/raspbian/installer/cavestory.zip
+        wget -O cavestory.zip "http://www.sheasilverman.com/rpi/raspbian/installer/cavestory.zip"
         unzip -oj cavestory.zip -d "$md_inst"
         rm cavestory.zip
     fi

--- a/scriptmodules/ports/nxengine.sh
+++ b/scriptmodules/ports/nxengine.sh
@@ -15,7 +15,7 @@ rp_module_help="The original Cave Story game files are automatically installed t
 rp_module_section="opt"
 
 function depends_nxengine() {
-    getDepends libsdl-ttf2.0-0 libsdl1.2
+    getDepends libsdl-ttf2.0-dev libsdl1.2-dev
 }
 
 function sources_nxengine() {

--- a/scriptmodules/ports/nxengine.sh
+++ b/scriptmodules/ports/nxengine.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="nxengine"
+rp_module_desc="Cave Story engine clone - NxEngine"
+rp_module_help="The original Cave Story game files are automatically installed to $md_inst."
+rp_module_section="opt"
+
+function depends_nxengine() {
+    getDepends libsdl-ttf2.0-0 libsdl1.2
+}
+
+function sources_nxengine() {
+    if isPlatform "rpi"; then 
+        wget -O- -q http://www.cavestory.org/downloads/pi-NXEngine-master.zip
+        unzip -oj pi-NXEngine-master.zip -d "$md_inst"
+        rm pi-NXEngine-master.zip
+        cd "$md_inst"
+        scons -j6
+    else
+        wget -O- -q http://nxengine.sourceforge.net/dl/nx-src-1006.tar.bz2 | tar -xvj --strip-components=1 -C "$md_inst"
+        rm nx-src-1006.tar.bz2
+        cd "$md_inst"
+        make clean
+        make
+    fi
+}
+
+function install_bin_nxengine() {
+    if isPlatform "rpi"; then
+        wget -O- -q http://www.sheasilverman.com/rpi/raspbian/installer/cavestory.zip
+        unzip -oj cavestory.zip -d "$md_inst"
+        rm cavestory.zip
+    fi
+    
+    if isPlatform "x86"; then
+        wget -O- -q http://nxengine.sourceforge.net/dl/nx-lin32-1002.tar.gz | tar -xvz --strip-components=1 -C "$md_inst"
+        rm nx-lin32-1002.tar.gz
+    fi       
+}
+
+function configure_nxengine() {
+    addPort "$md_id" "cavestory" "Cave Story" "$md_inst/nx"
+}


### PR DESCRIPTION
Binary is for RPI and for x86 only, other ARM platforms have to install from source instead.