### PR TITLE
Add standalone option to install Cave Story (NXEngine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ In the dialog box that comes up, you can select which users are allowed to use t
 - [X] - manaplus.sh - 2D MMORPG client - Tested and works well, requires mouse.  
 - [X] - maelstrom.sh - Classic Mac Asteroids Remake - Tested and works well, button configuration screen may crash.
 - [X] - mayhem.sh - Remake of the Amiga game - Tested and works well.
+- [X] - nxengine.sh - The standalone version of the open-source clone/rewrite of Cave Story - Tested and works well.
 - [X] - pingus.sh - Lemmings clone - Tested and works well, requires mouse.  
 - [X] - rawgl.sh - Another World source port - Tested, occasionally crashes when button held when switching scenes?  
 - [X] - reminiscence.sh - Flashback engine clone - Tested and works well.   

--- a/scriptmodules/ports/nxengine.sh
+++ b/scriptmodules/ports/nxengine.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="nxengine"
+rp_module_desc="Cave Story engine clone - NXEngine"
+rp_module_help="Copy the original Cave Story game files to /opt/retropie/ports/nxengine so you have the file /opt/retropie/ports/nxengine/Doukutsu.exe and folder /opt/retropie/ports/nxengine/data present."
+rp_module_section="opt"
+
+function depends_nxengine() {
+    getDepends libsdl1.2-dev libsdl-ttf2.0-dev
+}
+
+function sources_nxengine() {
+    wget -O- -q http://nxengine.sourceforge.net/dl/nx-src-1006.tar.bz2 | tar -xvj --strip-components=1
+}
+
+function build_nxengine() {
+    make clean
+    make
+}
+
+function install_nxengine() {
+    md_ret_files=('tilekey.dat'
+                  'sprites.sif'
+                  'smalfont.bmp'
+                  'nx'
+                  'font.ttf'
+                  'debug.txt'
+    )
+}
+
+function configure_nxengine() {
+    addPort "$md_id" "cavestory" "Cave Story" "$md_inst/NXEngine.sh"
+
+    cat >"$md_inst/NXEngine.sh" << _EOF_
+#!/bin/bash
+cd "$md_inst"
+./nx
+_EOF_
+    chmod +x "$md_inst/NXEngine.sh"
+
+}


### PR DESCRIPTION
The reason why the script has to write another script ([Starting at line 43](https://github.com/RetroPieNerd/RetroPie-Extra/blob/master/scriptmodules/ports/nxengine.sh#L43), [ending at line 47](https://github.com/RetroPieNerd/RetroPie-Extra/blob/master/scriptmodules/ports/nxengine.sh#L47)) is because the executable can't be called from afar and you have to cd into the directory, and then you execute the executable from in there to be able to work.  