### PR TITLE
Update chocolate-doom deps to SDL2

### DIFF
--- a/scriptmodules/ports/chocolate-doom.sh
+++ b/scriptmodules/ports/chocolate-doom.sh
@@ -16,7 +16,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
 
 function depends_chocolate-doom() {
-    getDepends libsdl1.2-dev libsdl-net1.2-dev libsdl-mixer1.2-dev python-imaging automake autoconf
+    getDepends libsdl2-dev libsdl2-net-dev libsdl2-mixer-dev libsamplerate0-dev libpng-dev python-imaging automake autoconf
 }
 
 function sources_chocolate-doom() {


### PR DESCRIPTION
chocolate-doom's default git branch is now the SDL2 version; update the build dependencies to reflect this.
Fixes #213