### PR TITLE
Update Xserver dependencies so that Xwrapper is installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In most cases, this is likely because the port requires external data files, esp
 Another possible case is the port uses the X11 windowing system. In some cases, I've included the X11 window system because of issues such as the game not going fullscreen, or just not functioning at all without it. In these cases, you will need to tell the system that it is okay for users other than root to use X11. You can do this by running the following command:
 
 ```
-dpkg-reconfigure x11-common
+dpkg-reconfigure xserver-xorg-common
 ```
 
 In the dialog box that comes up, you can select which users are allowed to use the X11 system. I would suggest you allow the pi user or anyone to run X11. This only needs to be done one time to fix the issue for all ports and programs that use the X11 window system. I would even suggest doing it now even if you have no intention yet of installing a port that uses X11 yet so that you do not need to deal with this issue in the future.

--- a/scriptmodules/ports/bloboats.sh
+++ b/scriptmodules/ports/bloboats.sh
@@ -15,7 +15,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
  
 function depends_bloboats() {
-    getDepends cmake xorg
+    getDepends cmake xorg xserver-xorg-legacy
 }
 
 function sources_bloboats() {

--- a/scriptmodules/ports/crack-attack.sh
+++ b/scriptmodules/ports/crack-attack.sh
@@ -16,7 +16,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
  
 function depends_crack-attack() {
-    getDepends cmake xorg
+    getDepends cmake xorg xserver-xorg-legacy
 }
 
 function sources_crack-attack() {

--- a/scriptmodules/ports/deadbeef.sh
+++ b/scriptmodules/ports/deadbeef.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
 
 function depends_deadbeef() {
-    	getDepends git autopoint libtool intltool libgtk-3-dev libjansson-dev automake autoconf xdg-utils matchbox xorg
+    	getDepends git autopoint libtool intltool libgtk-3-dev libjansson-dev automake autoconf xdg-utils matchbox xorg xserver-xorg-legacy
 }
 
 function sources_deadbeef() {

--- a/scriptmodules/ports/firefox-esr.sh
+++ b/scriptmodules/ports/firefox-esr.sh
@@ -16,7 +16,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
 
 function depends_firefox-esr() {
-    getDepends xorg matchbox
+    getDepends xorg matchbox xserver-xorg-legacy
 }
 
 function install_bin_firefox-esr() {

--- a/scriptmodules/ports/fofix.sh
+++ b/scriptmodules/ports/fofix.sh
@@ -16,7 +16,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
  
 function depends_fofix() {
-    getDepends cmake xorg
+    getDepends cmake xorg xserver-xorg-legacy
 }
 
 function sources_fofix() {

--- a/scriptmodules/ports/freeciv.sh
+++ b/scriptmodules/ports/freeciv.sh
@@ -17,7 +17,7 @@ rp_module_flags="!mali !x86"
 
 function depends_freeciv() {
     # Using xorg/xinit fixes issue where game couldn't get past opening menu screen.
-    getDepends xorg
+    getDepends xorg xserver-xorg-legacy
 }
 
 function install_bin_freeciv() {

--- a/scriptmodules/ports/freedink.sh
+++ b/scriptmodules/ports/freedink.sh
@@ -16,7 +16,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
 
 function depends_freedink() {
-    getDepends xorg
+    getDepends xorg xserver-xorg-legacy
 }
 
 function install_bin_freedink() {

--- a/scriptmodules/ports/manaplus.sh
+++ b/scriptmodules/ports/manaplus.sh
@@ -16,7 +16,7 @@ rp_module_section="exp"
 rp_module_flags="!x86 !mali"
 
 function depends_manaplus() {
-    getDepends libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libsdl-net1.2-dev libcurl4-gnutls-dev libpng12-dev libxml2-dev cmake libguichan-dev patch autoconf libtool libsdl-ttf2.0-dev libsdl-gfx1.2-dev gettext libgl1-mesa-dev libenet-dev libphysfs-dev libxml2-dev zlib1g-dev xorg
+    getDepends libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libsdl-net1.2-dev libcurl4-gnutls-dev libpng12-dev libxml2-dev cmake libguichan-dev patch autoconf libtool libsdl-ttf2.0-dev libsdl-gfx1.2-dev gettext libgl1-mesa-dev libenet-dev libphysfs-dev libxml2-dev zlib1g-dev xorg xserver-xorg-legacy
 }
 
 function sources_manaplus() {

--- a/scriptmodules/ports/openxcom.sh
+++ b/scriptmodules/ports/openxcom.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
  
 function depends_openxcom() {
-    getDepends cmake xorg libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libsdl-gfx1.2-dev libyaml-cpp-dev
+    getDepends cmake xorg libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libsdl-gfx1.2-dev libyaml-cpp-dev xserver-xorg-legacy
 }
 
 function sources_openxcom() {

--- a/scriptmodules/ports/retrobattle.sh
+++ b/scriptmodules/ports/retrobattle.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
 
 function depends_retrobattle() {
-    	getDepends libsdl1.2-dev libsdl-mixer1.2-dev xdg-utils matchbox xorg
+    	getDepends libsdl1.2-dev libsdl-mixer1.2-dev xdg-utils matchbox xorg xserver-xorg-legacy
 }
 
 function sources_retrobattle() {

--- a/scriptmodules/ports/supertuxkart.sh
+++ b/scriptmodules/ports/supertuxkart.sh
@@ -16,7 +16,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
  
 function depends_supertuxkart() {
-    getDepends cmake xorg
+    getDepends cmake xorg xserver-xorg-legacy
 }
 
 function sources_supertuxkart() {

--- a/scriptmodules/ports/tinyfugue.sh
+++ b/scriptmodules/ports/tinyfugue.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
 
 function depends_tinyfugue() {
-    	getDepends xdg-utils matchbox xorg
+    	getDepends xdg-utils matchbox xorg xserver-xorg-legacy
 }
 
 function install_bin_tinyfugue() {

--- a/scriptmodules/ports/weechat.sh
+++ b/scriptmodules/ports/weechat.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
 
 function depends_weechat() {
-    	getDepends xdg-utils matchbox xorg
+    	getDepends xdg-utils matchbox xorg xserver-xorg-legacy
 }
 
 function install_bin_weechat() {


### PR DESCRIPTION
XWrapper used to be a part of x11-common but has since moved to xserver-xorg-legacy, required for X11 apps to allow all users to use X.

Fix for #207.