### PR TITLE
Update libpng-dev dependency.

### DIFF
--- a/scriptmodules/ports/chocolate-doom.sh
+++ b/scriptmodules/ports/chocolate-doom.sh
@@ -17,7 +17,7 @@ rp_module_section="exp"
 rp_module_flags="!mali !x86"
 
 function depends_chocolate-doom() {
-    getDepends libsdl2-dev libsdl2-net-dev libsdl2-mixer-dev libsamplerate0-dev libpng-dev python-imaging automake autoconf
+    getDepends libsdl2-dev libsdl2-net-dev libsdl2-mixer-dev libsamplerate0-dev libpng12-dev python-imaging automake autoconf
 }
 
 function sources_chocolate-doom() {


### PR DESCRIPTION
Specifically ask for libpng12-dev instead of libpng-dev to avoid an installation error.