### PR TITLE
joystick_selection: solve symlink incompatibility

### DIFF
--- a/scriptmodules/supplementary/joystick-selection.sh
+++ b/scriptmodules/supplementary/joystick-selection.sh
@@ -19,8 +19,12 @@ function build_joystick-selection() {
 
 function install_joystick-selection() {
     local gamelistxml="$datadir/retropiemenu/gamelist.xml"
+    local rpmenu_js_sh="$datadir/retropiemenu/joystick_selection.sh"
 
-    ln -sfv "$md_inst/joystick_selection.sh" "$datadir/retropiemenu/joystick_selection.sh"
+    ln -sfv "$md_inst/joystick_selection.sh" "$rpmenu_js_sh"
+    # maybe the user is using a partition that doesn't support symbolic links...
+    [[ -L "$rpmenu_js_sh" ]] || cp -v "$md_inst/joystick_selection.sh" "$rpmenu_js_sh"
+
     cp -v "$md_build/icon.png" "$datadir/retropiemenu/icons/joystick_selection.png"
 
     cp -nv "$configdir/all/emulationstation/gamelists/retropie/gamelist.xml" "$gamelistxml"


### PR DESCRIPTION
Users using USB mounts were having problems. Now it's solved.

@zerojay good to see you back, by the way :)