### PR TITLE
Fixed GameMaker ports for Stretch

### DIFF
--- a/scriptmodules/ports/gamemaker.sh
+++ b/scriptmodules/ports/gamemaker.sh
@@ -25,6 +25,10 @@ function install_bin_gamemaker() {
     wget -O- -q https://www.yoyogames.com/download/pi/crate | tar -xvz -C "$md_inst"
     # Install Maldita Castilla Game
     wget -O- -q https://www.yoyogames.com/download/pi/castilla | tar -xvz -C "$md_inst"
+
+    patchVendorGraphics "$md_inst/TheyNeedToBeFed/TheyNeedToBeFed"
+    patchVendorGraphics "$md_inst/SuperCrateBox/SuperCrateBox"
+    patchVendorGraphics "$md_inst/MalditaCastilla/MalditaCastilla"
 }
 
 function configure_gamemaker() {
@@ -33,8 +37,4 @@ function configure_gamemaker() {
     addPort "$md_id" "TheyNeedToBeFed" "TheyNeedToBeFed" "$md_inst/TheyNeedToBeFed/TheyNeedToBeFed"
     addPort "$md_id" "SuperCrateBox" "SuperCrateBox" "$md_inst/SuperCrateBox/SuperCrateBox"
     addPort "$md_id" "MalditaCastilla" "MalditaCastilla" "$md_inst/MalditaCastilla/MalditaCastilla"
-
-    patchVendorGraphics "$md_inst/TheyNeedToBeFed/TheyNeedToBeFed"
-    patchVendorGraphics "$md_inst/SuperCrateBox/SuperCrateBox"
-    patchVendorGraphics "$md_inst/MalditaCastilla/MalditaCastilla"
 }

--- a/scriptmodules/ports/gamemaker.sh
+++ b/scriptmodules/ports/gamemaker.sh
@@ -33,4 +33,8 @@ function configure_gamemaker() {
     addPort "$md_id" "TheyNeedToBeFed" "TheyNeedToBeFed" "$md_inst/TheyNeedToBeFed/TheyNeedToBeFed"
     addPort "$md_id" "SuperCrateBox" "SuperCrateBox" "$md_inst/SuperCrateBox/SuperCrateBox"
     addPort "$md_id" "MalditaCastilla" "MalditaCastilla" "$md_inst/MalditaCastilla/MalditaCastilla"
+
+    patchVendorGraphics "$md_inst/TheyNeedToBeFed/TheyNeedToBeFed"
+    patchVendorGraphics "$md_inst/SuperCrateBox/SuperCrateBox"
+    patchVendorGraphics "$md_inst/MalditaCastilla/MalditaCastilla"
 }


### PR DESCRIPTION
These weren't working before because the runners were pointing to the old OpenGL ES driver locations, which were changed in Stretch.