### PR TITLE
Added Gnash - SWF player for Flash games

### DIFF
--- a/scriptmodules/emulators/gnash.sh
+++ b/scriptmodules/emulators/gnash.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+# 
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="gnash"
+rp_module_desc="gnash - Adobe Flash SWF Player"
+rp_module_help="ROM Extensions: .swf\n\nCopy your Flash games to $romdir/flash\n\nYou need to set video mode to CEA-1 in Runcommand."
+rp_module_licence="GPL3 http://git.savannah.gnu.org/cgit/gnash.git/tree/COPYING"
+rp_module_section="exp"
+rp_module_flags="!mali !kms"
+
+function depends_gnash() {
+	getDepends xinit
+}
+
+function install_bin_gnash() {
+	aptInstall gnash
+}
+
+function configure_gnash() {
+	mkRomDir "flash"
+	addEmulator 1 "$md_id" "flash" "sudo xinit -e 'gnash %ROM%  -j 640 -k 480 --hide-menubar' -- :0"
+	addSystem "flash"
+}

--- a/scriptmodules/emulators/gnash.sh
+++ b/scriptmodules/emulators/gnash.sh
@@ -18,7 +18,6 @@ rp_module_flags="!mali !kms"
 
 function depends_gnash() {
 	getDepends xinit xorg
-	sudo chmod ug+s /usr/lib/xorg/Xorg #Fixes sudo permissions bug for X
 }
 
 function install_bin_gnash() {

--- a/scriptmodules/emulators/gnash.sh
+++ b/scriptmodules/emulators/gnash.sh
@@ -26,7 +26,8 @@ function install_bin_gnash() {
 
 function configure_gnash() {
 	mkRomDir "flash"
-	addEmulator 1 "$md_id" "flash" "sudo xinit -e 'gnash %ROM%  -j 640 -k 480 --hide-menubar' -- :0"
+	addEmulator 1 "$md_id" "flash" "sudo xinit -e 'gnash -j 640 -k 480 --hwaccel vaapi --hide-menubar %ROM%' -- :0"
 	addSystem "flash"
 	grep -qF 'gnash = "CEA-1"' $md_conf_root/all/videomodes.cfg || echo 'gnash = "CEA-1"' >> $md_conf_root/all/videomodes.cfg
+	sudo sed -i 's/set quality -1/set quality 0/g' /root/.gnashrc
 }

--- a/scriptmodules/emulators/gnash.sh
+++ b/scriptmodules/emulators/gnash.sh
@@ -11,8 +11,8 @@
 
 rp_module_id="gnash"
 rp_module_desc="gnash - Adobe Flash SWF Player"
-rp_module_help="ROM Extensions: .swf\n\nCopy your Flash games to $romdir/flash"
-rp_module_licence="GPL3 http://git.savannah.gnu.org/cgit/gnash.git/tree/COPYING"
+rp_module_help="ROM Extensions: .swf\n\nCopy your Flash games to $romdir/flash\n\nTo change resolution, open emulators.cfg and add parameters -j and -k with width and height values.\n\nSetting video mode to CEA-1 in runcommand and setting -j and -k to 640x480 yields best performance at the cost of image quality."
+rp_module_licence="GPL3 https://github.com/strk/gnash/blob/master/COPYING"
 rp_module_section="exp"
 rp_module_flags="!mali !kms"
 
@@ -26,8 +26,7 @@ function install_bin_gnash() {
 
 function configure_gnash() {
 	mkRomDir "flash"
-	addEmulator 1 "$md_id" "flash" "sudo xinit -e 'gnash -j 640 -k 480 --hwaccel vaapi --hide-menubar %ROM%' -- :0"
+	addEmulator 1 "$md_id" "flash" "sudo xinit -e 'gnash %ROM% --hwaccel vaapi --hide-menubar' -- :0"
 	addSystem "flash"
-	grep -qF 'gnash = "CEA-1"' $md_conf_root/all/videomodes.cfg || echo 'gnash = "CEA-1"' >> $md_conf_root/all/videomodes.cfg
 	sudo sed -i 's/set quality -1/set quality 0/g' /root/.gnashrc
 }

--- a/scriptmodules/emulators/gnash.sh
+++ b/scriptmodules/emulators/gnash.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="gnash"
 rp_module_desc="gnash - Adobe Flash SWF Player"
-rp_module_help="ROM Extensions: .swf\n\nCopy your Flash games to $romdir/flash\n\nYou need to set video mode to CEA-1 in Runcommand."
+rp_module_help="ROM Extensions: .swf\n\nCopy your Flash games to $romdir/flash"
 rp_module_licence="GPL3 http://git.savannah.gnu.org/cgit/gnash.git/tree/COPYING"
 rp_module_section="exp"
 rp_module_flags="!mali !kms"

--- a/scriptmodules/emulators/gnash.sh
+++ b/scriptmodules/emulators/gnash.sh
@@ -28,5 +28,5 @@ function configure_gnash() {
 	mkRomDir "flash"
 	addEmulator 1 "$md_id" "flash" "sudo xinit -e 'gnash %ROM%  -j 640 -k 480 --hide-menubar' -- :0"
 	addSystem "flash"
-	echo 'gnash = "CEA-1"' >> $md_conf_root/all/videomodes.cfg
+	grep -qF 'gnash = "CEA-1"' $md_conf_root/all/videomodes.cfg || echo 'gnash = "CEA-1"' >> $md_conf_root/all/videomodes.cfg
 }

--- a/scriptmodules/emulators/gnash.sh
+++ b/scriptmodules/emulators/gnash.sh
@@ -28,4 +28,5 @@ function configure_gnash() {
 	mkRomDir "flash"
 	addEmulator 1 "$md_id" "flash" "sudo xinit -e 'gnash %ROM%  -j 640 -k 480 --hide-menubar' -- :0"
 	addSystem "flash"
+	echo 'gnash = "CEA-1"' >> $md_conf_root/all/videomodes.cfg
 }

--- a/scriptmodules/emulators/gnash.sh
+++ b/scriptmodules/emulators/gnash.sh
@@ -17,7 +17,8 @@ rp_module_section="exp"
 rp_module_flags="!mali !kms"
 
 function depends_gnash() {
-	getDepends xinit
+	getDepends xinit xorg
+	sudo chmod ug+s /usr/lib/xorg/Xorg #Fixes sudo permissions bug for X
 }
 
 function install_bin_gnash() {
@@ -26,7 +27,6 @@ function install_bin_gnash() {
 
 function configure_gnash() {
 	mkRomDir "flash"
-	addEmulator 1 "$md_id" "flash" "sudo xinit -e 'gnash %ROM% --hwaccel vaapi --hide-menubar' -- :0"
+	addEmulator 1 "$md_id" "flash" "xinit -e 'gnash --hwaccel vaapi --hide-menubar %ROM%'"
 	addSystem "flash"
-	sudo sed -i 's/set quality -1/set quality 0/g' /root/.gnashrc
 }


### PR DESCRIPTION
Added Gnash script.  I couldn't quite figure out the proper way to write the `addEmulator` command while adhering to the Script Style Guide used by RetroPie, so feel free to rewrite that portion of the script.

This isn't really an emulator per-se (calling it one would be like calling VLC an MP4 emulator), but it doesn't quite fit into ports either since you have to supply your own games.

Terminology aside, I've tested this on my Pi 3 non-overclocked and it runs older games pretty well all things considered; however it can't properly run games made past SWF 10 (which rougly covers everything made after 2009 or so), and performace is pretty spotty on more intensive games such as Mario 63.

I should also note that there's [a Github repository](https://github.com/strk/gnash) available, if you want to write a source-build version of this script (though commits seem to be few and far between, so it's not exactly going to be very practical).